### PR TITLE
ASLR Support

### DIFF
--- a/src/core/Breakpoint.cpp
+++ b/src/core/Breakpoint.cpp
@@ -4,11 +4,9 @@
 void procmsg(const char *format, ...);
 unsigned getChildInstructionPointer(pid_t child_pid);
 
-Breakpoint::Breakpoint(uint64_t addr, uint64_t line_number, std::string file_name)
+Breakpoint::Breakpoint(uint64_t addr)
 {
 	this->addr = addr;
-	this->line_number = line_number;
-	this->file_name = file_name;
 
 	procmsg("Breakpoint created: 0x%08x\n", addr);
 }
@@ -17,8 +15,6 @@ Breakpoint::Breakpoint(Breakpoint &&other)
 {
 	this->addr = other.addr;
 	this->orig_data = other.orig_data;
-	this->line_number = other.line_number;
-	this->file_name = std::move(other.file_name);
 }
 
 // Enables this breakpoint by replacing the instruction at its assigned address
@@ -101,6 +97,4 @@ Breakpoint &Breakpoint::operator=(Breakpoint &&other)
 {
 	this->addr = other.addr;
 	this->orig_data = other.orig_data;
-	this->line_number = other.line_number;
-	this->file_name = std::move(other.file_name);
 }

--- a/src/core/Breakpoint.hpp
+++ b/src/core/Breakpoint.hpp
@@ -26,8 +26,6 @@ public:
 
 	uint64_t addr;
 	uint64_t orig_data;
-	uint64_t line_number;
-	std::string file_name;
 
 	Breakpoint(const Breakpoint &other) = delete;
 	Breakpoint(Breakpoint &&other);
@@ -40,5 +38,5 @@ public:
 	Breakpoint &operator=(Breakpoint &&other);
 
 private:
-	Breakpoint(uint64_t addr, uint64_t line_number = 0, std::string file_name = "");
+	Breakpoint(uint64_t addr);
 };

--- a/src/core/BreakpointTable.hpp
+++ b/src/core/BreakpointTable.hpp
@@ -10,31 +10,23 @@
 #include <mutex>
 
 #include "Breakpoint.hpp"
-#include "DebugInfo.hpp"
 #include "ProcessTracer.hpp"
 
 class BreakpointTable
 {
 public:
-	BreakpointTable(std::shared_ptr<DebugInfo> debug_info);
+	BreakpointTable();
 
 	void addBreakpoint(uint64_t address);
 	void removeBreakpoint(uint64_t address);
 	Breakpoint &getBreakpoint(uint64_t address);
 
-	bool addBreakpoint(const char *source_file, unsigned int line_number);
-	bool removeBreakpoint(const char *source_file, unsigned int line_number);
-
 	void enableBreakpoints(ProcessTracer& tracer);
 	void disableBreakpoints(ProcessTracer& tracer);
 
 	bool isBreakpoint(uint64_t address);
-	bool isBreakpoint(const std::string &source_file, unsigned int line_number);
 
 private:
-	std::shared_ptr<DebugInfo> debug_info = nullptr;
-
 	std::mutex mtx;
-
 	std::unordered_map<uint64_t, Breakpoint> breakpoints_by_address;
 };

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(vdb SHARED
 	BreakpointTable.cpp
 	DebugEngine.cpp
 	DebugInfo.cpp
+	ELFFile.cpp
 	ProcessDebugger.cpp
 	ProcessTracer.cpp
 	StepCursor.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(vdb SHARED
 	DebugInfo.cpp
 	ELFFile.cpp
 	ProcessDebugger.cpp
+	ProcessMemoryMappings.cpp
 	ProcessTracer.cpp
 	StepCursor.cpp
 	Unwinder.cpp

--- a/src/core/DebugEngine.cpp
+++ b/src/core/DebugEngine.cpp
@@ -4,7 +4,7 @@ DebugEngine::DebugEngine(const std::string& executable_name, std::shared_ptr<Deb
 	target_name(executable_name),
 	debug_info(debug_info)
 {
-	breakpoint_table = std::make_shared<BreakpointTable>(debug_info);
+
 }
 
 DebugEngine::~DebugEngine()
@@ -14,13 +14,57 @@ DebugEngine::~DebugEngine()
 
 bool DebugEngine::run()
 {
-	debugger = std::make_shared<ProcessDebugger>(target_name, breakpoint_table, debug_info);
+	debugger = std::make_shared<ProcessDebugger>(target_name, breakpoint_lines, debug_info);
 	return true;
 }
 
-std::shared_ptr<BreakpointTable> DebugEngine::getBreakpoints()
+bool DebugEngine::addBreakpoint(const char* source_file, unsigned int line_number)
 {
-	return breakpoint_table;
+	BreakpointLine line;
+	line.line_number = line_number;
+	line.file_name = source_file;
+
+	auto it = std::find(std::begin(breakpoint_lines), std::end(breakpoint_lines), line);
+	bool does_not_exist = it == std::end(breakpoint_lines);
+	if (does_not_exist)
+	{
+		breakpoint_lines.push_back(line);
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool DebugEngine::removeBreakpoint(const char* source_file, unsigned int line_number)
+{
+	BreakpointLine line;
+	line.line_number = line_number;
+	line.file_name = source_file;
+
+	auto it = std::find(std::begin(breakpoint_lines), std::end(breakpoint_lines), line);
+	bool does_exist = it != std::end(breakpoint_lines);
+	if (does_exist)
+	{
+		breakpoint_lines.erase(it);
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool DebugEngine::isBreakpoint(const char* source_file, unsigned int line_number)
+{
+	BreakpointLine line;
+	line.line_number = line_number;
+	line.file_name = source_file;
+
+	auto it = std::find(std::begin(breakpoint_lines), std::end(breakpoint_lines), line);
+	bool does_exist = it != std::end(breakpoint_lines);
+	return does_exist;
 }
 
 void DebugEngine::stepOver()

--- a/src/core/DebugEngine.hpp
+++ b/src/core/DebugEngine.hpp
@@ -24,7 +24,9 @@ public:
 
 	bool run();
 
-	std::shared_ptr<BreakpointTable> getBreakpoints();
+	bool addBreakpoint(const char* source_file, unsigned int line_number);
+	bool removeBreakpoint(const char* source_file, unsigned int line_number);
+	bool isBreakpoint(const char* source_file, unsigned int line_number);
 
 	void stepOver();
 	void stepInto();
@@ -41,5 +43,5 @@ private:
 
 	std::shared_ptr<ProcessDebugger> debugger = nullptr;
 	std::shared_ptr<DebugInfo> debug_info = nullptr;
-	std::shared_ptr<BreakpointTable> breakpoint_table = nullptr;
+	std::vector<BreakpointLine> breakpoint_lines;
 };

--- a/src/core/ELFFile.cpp
+++ b/src/core/ELFFile.cpp
@@ -1,0 +1,52 @@
+#include "ELFFile.hpp"
+
+#include <stdint.h>
+#include <gelf.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cassert>
+
+ELFFile::ELFFile(std::string path) :
+	file_path(std::move(path))
+{
+	type = getType(file_path);
+}
+
+std::string ELFFile::filePath() const
+{
+	return file_path;
+}
+
+bool ELFFile::hasPositionIndependentCode() const
+{
+	return type == ET_DYN;
+}
+
+uint16_t ELFFile::getType(const std::string& file_path)
+{
+	// Ensure the ELF library initialization doesn't fail
+	assert(elf_version(EV_CURRENT) != EV_NONE);
+
+	// Ensure the executable file can be read successfully
+	int fd = open(file_path.c_str(), O_RDONLY, 0);
+	assert(fd >= 0);
+
+	Elf* elf = elf_begin(fd, ELF_C_READ, NULL);
+	assert(elf != NULL);
+
+	// Ensure the executable is an ELF object
+	assert(elf_kind(elf) == ELF_K_ELF);
+
+	GElf_Ehdr elf_header;
+	if (gelf_getehdr(elf, &elf_header) == NULL)
+	{
+		assert(false);
+	}
+
+	uint16_t file_type = elf_header.e_type;
+
+	elf_end(elf);
+	close(fd);
+
+	return file_type;
+}

--- a/src/core/ELFFile.hpp
+++ b/src/core/ELFFile.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+class ELFFile
+{
+public:
+	ELFFile(std::string file_path);
+
+	std::string filePath() const;
+	bool hasPositionIndependentCode() const;
+
+private:
+	std::string file_path;
+	uint16_t type;
+
+	uint16_t getType(const std::string& file_path);
+};

--- a/src/core/ProcessDebugger.cpp
+++ b/src/core/ProcessDebugger.cpp
@@ -182,6 +182,11 @@ void ProcessDebugger::createBreakpoints()
 				uint64_t bp_address = start_address_offset + line.address;
 				breakpoint_table->addBreakpoint(bp_address);
 				breakpoint_lines_by_address.emplace(bp_address, bp_line);
+
+				// TODO: By breaking here, you are assuming the first address found is
+				// the lowest address of this source line's assembly. This may be
+				// changed in future versions.
+				break;
 			}
 		}
 	}

--- a/src/core/ProcessMemoryMappings.cpp
+++ b/src/core/ProcessMemoryMappings.cpp
@@ -1,0 +1,36 @@
+#include "ProcessMemoryMappings.hpp"
+
+#include <fstream>
+#include <string>
+
+void procmsg(const char* format, ...);
+
+ProcessMemoryMappings::ProcessMemoryMappings(pid_t pid)
+{
+	load_address = readLoadAddressFromProcMaps(pid);
+}
+
+uint64_t ProcessMemoryMappings::loadAddress() const
+{
+	return load_address;
+}
+
+uint64_t ProcessMemoryMappings::readLoadAddressFromProcMaps(pid_t pid)
+{
+	std::string pmaps_path = "/proc/" + std::to_string(pid) + "/maps";
+
+	// DEBUG: Print out the entire file for debugging purposes
+	std::ifstream file(pmaps_path);
+	std::string line;
+	std::string first_line;
+	while (std::getline(file, line))
+	{
+		if (first_line.empty())
+			first_line = line;
+		procmsg("%s\n", line.c_str());
+	}
+
+	std::string load_addr_str = first_line.substr(0, first_line.find("-"));
+	uint64_t load_addr = std::stoull(load_addr_str, 0, 16);
+	return load_addr;
+}

--- a/src/core/ProcessMemoryMappings.hpp
+++ b/src/core/ProcessMemoryMappings.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <sys/types.h>
+
+#include <stdint.h>
+
+class ProcessMemoryMappings
+{
+public:
+	ProcessMemoryMappings(pid_t pid);
+
+	uint64_t loadAddress() const;
+
+private:
+	uint64_t load_address;
+
+	uint64_t readLoadAddressFromProcMaps(pid_t pid);
+};

--- a/src/core/StepCursor.cpp
+++ b/src/core/StepCursor.cpp
@@ -184,7 +184,7 @@ void StepCursor::addReturnBreakpoint(BreakpointTable &internal,
 		bool is_closer_address = loaded_address < next_closest_address;
 		if (is_higher_address && is_closer_address)
 		{
-			next_closest_address = line.address;
+			next_closest_address = loaded_address;
 			address_found = true;
 		}
 	}

--- a/src/core/StepCursor.hpp
+++ b/src/core/StepCursor.hpp
@@ -22,7 +22,8 @@ class StepCursor
 {
 public:
 	StepCursor(std::shared_ptr<DebugInfo> debug_info,
-	           std::shared_ptr<BreakpointTable> user_breakpoints);
+	           std::shared_ptr<BreakpointTable> user_breakpoints,
+	           uint64_t load_address_offset);
 
 	void stepOver(ProcessTracer& tracer);
 	void stepInto(ProcessTracer& tracer);
@@ -35,6 +36,7 @@ public:
 private:
 	std::shared_ptr<DebugInfo> debug_info = nullptr;
 	std::shared_ptr<BreakpointTable> user_breakpoints = nullptr;
+	uint64_t load_address_offset;
 
 	void addSubprogramBreakpoints(BreakpointTable &internal, ProcessTracer& tracer,
 	                              uint64_t address);

--- a/src/ui/codeeditor.cpp
+++ b/src/ui/codeeditor.cpp
@@ -156,8 +156,8 @@ void CodeEditor::lineNumberAreaPaintEvent(QPaintEvent *event)
             painter.setPen(Qt::black);
 
             // Color the number's background red if it has an assigned breakpoint
-            std::shared_ptr<BreakpointTable> table = vdb->getDebugEngine()->getBreakpoints();
-            if (table->isBreakpoint(this->filepath.toStdString(), block_number + 1))
+            std::shared_ptr<DebugEngine> engine = vdb->getDebugEngine();
+            if (engine->isBreakpoint(this->filepath.toStdString().c_str(), block_number + 1))
             {
                 painter.fillRect(QRectF(0, top, line_number_area->width(), fontMetrics().height()), Qt::red);
             }
@@ -193,14 +193,14 @@ unsigned int CodeEditor::getLineNumberFromY(int y)
 
 void CodeEditor::toggleBreakpoint(unsigned int line_number)
 {
-    std::shared_ptr<BreakpointTable> table = vdb->getDebugEngine()->getBreakpoints();
-    if (table->isBreakpoint(this->filepath.toStdString(), line_number))
+    std::shared_ptr<DebugEngine> engine = vdb->getDebugEngine();
+    if (engine->isBreakpoint(this->filepath.toStdString().c_str(), line_number))
     {
-        vdb->getDebugEngine()->getBreakpoints()->removeBreakpoint(filepath.toStdString().c_str(), line_number);
+        engine->removeBreakpoint(filepath.toStdString().c_str(), line_number);
     }
     else
     {
-        vdb->getDebugEngine()->getBreakpoints()->addBreakpoint(filepath.toStdString().c_str(), line_number);
+        engine->addBreakpoint(filepath.toStdString().c_str(), line_number);
     }
 }
 

--- a/tests/core/BreakpointsTest.cpp
+++ b/tests/core/BreakpointsTest.cpp
@@ -11,32 +11,31 @@ TEST_CASE("Breakpoint testing")
 	vdb.init("data/hello_world");
 
 	std::shared_ptr<DebugEngine> engine = vdb.getDebugEngine();
-	std::shared_ptr<BreakpointTable> table = engine->getBreakpoints();
 
 	const std::string source_file = std::string(VDB_TEST_DIR) + "/data/hello_world.cpp";
 	const unsigned int source_line = 6;
 
 	SECTION("Check for a non-existant breakpoint")
 	{
-		REQUIRE(table->isBreakpoint(source_file, source_line) == false);
+		REQUIRE(engine->isBreakpoint(source_file.c_str(), source_line) == false);
 	}
 
 	SECTION("Setting a breakpoint")
 	{
-		table->addBreakpoint(source_file.c_str(), source_line);
-		REQUIRE(table->isBreakpoint(source_file, source_line) == true);
+		engine->addBreakpoint(source_file.c_str(), source_line);
+		REQUIRE(engine->isBreakpoint(source_file.c_str(), source_line) == true);
 	}
 
 	SECTION("Removing an existing breakpoint")
 	{
-		table->removeBreakpoint(source_file.c_str(), source_line);
-		REQUIRE(table->isBreakpoint(source_file, source_line) == false);
+		engine->removeBreakpoint(source_file.c_str(), source_line);
+		REQUIRE(engine->isBreakpoint(source_file.c_str(), source_line) == false);
 	}
 
 	SECTION("Debuggee halting at an enabled breakpoint")
 	{
 		// Set the breakpoint
-		table->addBreakpoint(source_file.c_str(), source_line);
+		engine->addBreakpoint(source_file.c_str(), source_line);
 
 		// Run the tatget process until it encounters the breakpoint
 		engine->run();

--- a/tests/core/StepIntoTest.cpp
+++ b/tests/core/StepIntoTest.cpp
@@ -6,10 +6,9 @@
 std::unique_ptr<StepMessage> stepInto(VDB& vdb, const std::string& source_file, unsigned int source_line)
 {
 	std::shared_ptr<DebugEngine> engine = vdb.getDebugEngine();
-	std::shared_ptr<BreakpointTable> table = engine->getBreakpoints();
 
 	// Set the breakpoint
-	table->addBreakpoint(source_file.c_str(), source_line);
+	engine->addBreakpoint(source_file.c_str(), source_line);
 
 	// Run the target process until it encounters the breakpoint
 	engine->run();

--- a/tests/core/VariablesTest.cpp
+++ b/tests/core/VariablesTest.cpp
@@ -31,14 +31,13 @@ TEST_CASE("Fundamental type value deduction")
 	vdb.init("data/variables");
 
 	std::shared_ptr<DebugEngine> engine = vdb.getDebugEngine();
-	std::shared_ptr<BreakpointTable> table = engine->getBreakpoints();
 
 	// Set the breakpoint location on the return statement
 	const std::string source_file = std::string(VDB_TEST_DIR) + "/data/variables.cpp";
 	const unsigned int source_line = 69;
 
 	// Set the breakpoint
-	table->addBreakpoint(source_file.c_str(), source_line);
+	engine->addBreakpoint(source_file.c_str(), source_line);
 
 	// Run the target process until it encounters the breakpoint
 	engine->run();


### PR DESCRIPTION
Adds support for parsing the DWARF data of ELF executables compiled with position-independent code. The following changes were made to accommodate this:

- The load address of the executable is read from `/proc/id/map` if the ELF file type is dynamic (recorded in the file header).
- `Breakpoint` instances no longer contain line or file information. Source file and line information is recorded by `DebugEngine` before debuggee tracing begins.
- `Breakpoint` instances are instantiated only when debuggee tracing starts. The source file and line information is combined with the load address to set breakpoints appropriately.

Resolves #1 